### PR TITLE
vscpworks assertions fixed

### DIFF
--- a/src/vscp/vscpworks/frmdeviceconfig.cpp
+++ b/src/vscp/vscpworks/frmdeviceconfig.cpp
@@ -3403,7 +3403,9 @@ void frmDeviceConfig::OnButtonUpdateClick( wxCommandEvent& event )
                 wxMessageBox( _("MDF returns zero pages (which is an error) we still will read one page."), 
                                 _("VSCP Works"), 
                                 wxICON_WARNING );
+                // Add standard page
                 n = 1;
+                pageArray.Add(0);
             }
 
             m_userRegisters.init( pageArray );

--- a/src/vscp/vscpworks/frmdeviceconfig.cpp
+++ b/src/vscp/vscpworks/frmdeviceconfig.cpp
@@ -3246,7 +3246,9 @@ void frmDeviceConfig::OnButtonUpdateClick( wxCommandEvent& event )
                 wxMessageBox( _("MDF returns zero pages (which is an error) we still will read one page."), 
                                 _("VSCP Works"), 
                                 wxICON_WARNING );
+                // Add standard page
                 nPages = 1;
+                pageArray.Add(0);
             }
 
             m_userRegisters.init( pageArray );


### PR DESCRIPTION
Hi Ake,
both assertions happened, because no mdf was available.

The problem that the register update doesn't work is, that the communication via tcp/ip is too slow. Increasing the TCPIP_REGISTER_READ_RESEND_TIMEOUT from 1000 to 5000 and it works.
But because I am not sure that to increase the define is the right place for the bugix, please check it.

Best regards
Andreas