### PR TITLE
Precondition for vscp_makeFloatMeasurementEvent is that the payload isnt...

### DIFF
--- a/src/vscp/common/vscphelper.cpp
+++ b/src/vscp/common/vscphelper.cpp
@@ -837,13 +837,13 @@ bool vscp_makeFloatMeasurementEvent( vscpEvent *pEvent,
     uint8_t offset = 0;
     
     // Allocate data if needed
-    if ( ( NULL != pEvent->pdata ) && 
+    if ( ( NULL == pEvent->pdata ) && 
             ( VSCP_CLASS1_MEASUREMENT == pEvent->vscp_class ) ) {
         offset = 0;
         pEvent->pdata = new uint8_t[ 16 + 5 ];
         if ( NULL == pEvent->pdata ) return false;
     }
-    else if ( ( NULL != pEvent->pdata ) &&
+    else if ( ( NULL == pEvent->pdata ) &&
             ( VSCP_CLASS2_LEVEL1_MEASUREMENT == pEvent->vscp_class ) ) {
         offset = 16;
         pEvent->pdata = new uint8_t[ 5 ];


### PR DESCRIPTION
...'t allocated yet.

Because of the precondition, only in case that the event data pointer is NULL, new data is allocated.