### PR TITLE
Missing return statement added.

### DIFF
--- a/src/vscp/vscpworks/devicebootloaderwizard.cpp
+++ b/src/vscp/vscpworks/devicebootloaderwizard.cpp
@@ -1368,6 +1368,7 @@ void WizardPageSelectBootloader::fetchAlgorithmFromMdf( void )
 
         if ( !pblw->m_mdf.load( mdfurl ) ) {
             wxMessageBox( _( "Failed to load MDF!" ) );
+            return;
         }
 
         // MDF has been fetched -


### PR DESCRIPTION
This problem causes a XML parse error, although no mdf was loaded.