### PR TITLE
Set CANAL_USB2CAN_DRIVER_MAX_OPEN to 4, which is equal to CEnum::MAX_…

### DIFF
--- a/src/vscp/drivers/level1/usb2can/usb2can/common/dlldrvobj.h
+++ b/src/vscp/drivers/level1/usb2can/usb2can/common/dlldrvobj.h
@@ -39,7 +39,7 @@
 
 // Max number of open connections
 //#define CANAL_USB2CAN_DRIVER_MAX_OPEN	256
-#define CANAL_USB2CAN_DRIVER_MAX_OPEN	1
+#define CANAL_USB2CAN_DRIVER_MAX_OPEN	4
 //WARNING! CANAL_USB2CAN_DRIVER_MAX_OPEN will be a problem with using old version with smaller size and a new version with bigger size on the same pc at the same time
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
…USB_DEVICES. Now up to 4 usb2can adapter can be connected.

This relates to #127 